### PR TITLE
integrate XmlParser and CType from haxe dev branch

### DIFF
--- a/chxdoc/TypeHandler.hx
+++ b/chxdoc/TypeHandler.hx
@@ -114,7 +114,7 @@ class TypeHandler<T> {
 			var me = this;
 			display(fields,function(f) {
 				me.write(f.name+" : ");
-				me.processType(f.t);
+				me.processType(f.type);
 			},", ");
 			write("}");
 		case CDynamic(t):

--- a/chxdoc/TypedefHandler.hx
+++ b/chxdoc/TypedefHandler.hx
@@ -108,7 +108,7 @@ class TypedefHandler extends TypeHandler<TypedefCtx> {
 				var field = createField(context, f.name, false, platforms, "", null);
 				field.returns =  doStringBlock(
 						function() {
-							me.processType(f.t);
+							me.processType(f.type);
 						}
 				);
 				context.fields.push(field);


### PR DESCRIPTION
new XmlParser parses the "this" nodes correctly, which fixes the crash as
described in #4. In fact, with the new CType, it no longer seems
necessary to keep our own custom CType/XmlParser, and we should just use
the one provided in std.
